### PR TITLE
Force using 'en-US' to avoid locale-specific extra strings

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -43,7 +43,7 @@ function NewDateTimeFormat(options) {
   if (options.timeZone) {
     options.timeZone = getChromeTimeZone(options.timeZone);
   }
-  return new Intl.DateTimeFormat(undefined, options);
+  return new Intl.DateTimeFormat('en-US', options);
 }
 
 function IsTimezoneSupported(timezone) {


### PR DESCRIPTION
This fixes the exception and to get the hour hand working.